### PR TITLE
Factor out "generate" into separate command-line util

### DIFF
--- a/encayagen/encayagen.go
+++ b/encayagen/encayagen.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/hlandau/dexlogconfig"
+	"gopkg.in/hlandau/easyconfig.v1"
+
+	"github.com/namecoin/encaya/server"
+)
+
+func main() {
+	cfg := server.Config{}
+
+	config := easyconfig.Configurator{
+		ProgramName: "encaya",
+	}
+	config.ParseFatal(&cfg)
+	dexlogconfig.Init()
+
+	// We use the configPath to resolve paths relative to the config file.
+	cfg.ConfigDir = filepath.Dir(config.ConfigFilePath())
+
+	server.GenerateCerts(&cfg)
+}
+
+// © 2014-2021 Namecoin Developers    GPLv3 or later


### PR DESCRIPTION
This reduces attack surface by removing cert generation code from the run-time service that handles untrusted network data.

Also should work around the hlandau/service bug that's causing Cirrus CI VM's to always be detected as a service.