### PR TITLE
CI: Whitelist go.mod replace x509-compressed

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,7 @@
 linters-settings:
   goimports:
     local-prefixes: "github.com/namecoin"
+  gomoddirectives:
+    replace-local: true
+    replace-allow-list:
+      - "github.com/namecoin/x509-compressed"


### PR DESCRIPTION
Fixes a warning from gomoddirectives linter.