### PR TITLE
Return 404 status code if requested pubkey doesn't match DNS response

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -560,13 +560,18 @@ func (s *Server) aiaHandler(w http.ResponseWriter, req *http.Request) {
 			continue
 		}
 
+		// Success.  Send the cert as a response.
 		_, err = io.WriteString(w, string(safeCert))
 		if err != nil {
 			log.Debuge(err, "write error")
 		}
 
-		break
+		// Only send 1 cert in the response.
+		return
 	}
+
+	// Requested public key hash doesn't match the DNS response.
+	w.WriteHeader(404)
 }
 
 func (s *Server) getNewNegativeCAHandler(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
I don't *think* sending an empty 200 response was actually breaking any TLS clients, but it was still clearly wrong behavior.