### PR TITLE
(WIP) Add optional Pi meta-domain

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -197,6 +197,11 @@ task:
         - go mod init
         - go mod edit -replace gopkg.in/alecthomas/kingpin.v2=$(go env GOPATH)/src/github.com/alecthomas/kingpin
         - go mod tidy
+  matrix:
+    - env:
+        GOX_TAGS: ""
+    - env:
+        GOX_TAGS: "encaya_pi"
   build_script:
     - rm -rf idist
     - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
@@ -208,7 +213,6 @@ task:
   binaries_artifacts:
     path: "dist/*"
   env:
-    GOX_TAGS: ""
     GO_VERSION: latest
 
 task:

--- a/server/pi_disabled.go
+++ b/server/pi_disabled.go
@@ -1,0 +1,15 @@
+//go:build !encaya_pi
+// +build !encaya_pi
+
+package server
+
+import (
+	"net/http"
+
+	"github.com/miekg/dns"
+)
+
+func (s *Server) lookupPi(req *http.Request, domain string) (tlsa *dns.TLSA, err error) {
+	// No DNS records matched. Return no cert.
+	return nil, nil
+}

--- a/server/pi_enabled.go
+++ b/server/pi_enabled.go
@@ -1,0 +1,60 @@
+//go:build encaya_pi
+// +build encaya_pi
+
+package server
+
+import (
+	"crypto/x509"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/ferhatelmas/pi"
+	"github.com/miekg/dns"
+)
+
+func (s *Server) lookupPi(req *http.Request, domain string) (tlsa *dns.TLSA, err error) {
+	// Pi meta-domains are of the form INTEGER.pi.x--nmc.bit
+	metaSuffix := ".pi.x--nmc.bit"
+	if !strings.HasSuffix(domain, metaSuffix) {
+		return nil, nil
+	}
+
+	digitCountStr := strings.TrimSuffix(domain, metaSuffix)
+
+	digitCount, err := strconv.Atoi(digitCountStr)
+	if err != nil {
+		return nil, nil
+	}
+
+	purportedDigits := req.FormValue("pidigits")
+
+	actualDigits := pi.Digits(digitCount)
+
+	if purportedDigits != actualDigits {
+		return nil, nil
+	}
+
+	// Check has passed, now we just return a pubkey. For now we reuse the TLD
+	// key, because using a separate key would be more effort and this is just
+	// a debug thing.
+
+	pub := &s.tldPriv.PublicKey
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+
+	pubHex := hex.EncodeToString(pubBytes)
+
+	return &dns.TLSA{
+		Hdr: dns.RR_Header{Name: "", Rrtype: dns.TypeTLSA, Class: dns.ClassINET,
+			Ttl: 600},
+		Usage:        2,
+		Selector:     1,
+		MatchingType: 0,
+		Certificate:  strings.ToUpper(pubHex),
+	}, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -470,9 +470,21 @@ func (s *Server) lookupCert(req *http.Request) (certDer []byte, shortTerm bool, 
 		return nil, false, nil
 	}
 
-	tlsa, err := lookupDNS(req, domain)
+	tlsa, err := lookupPi(req, domain)
 	if err != nil {
 		return nil, false, err
+	}
+
+	if tlsa == nil {
+		tlsa, err := lookupDNS(req, domain)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	// TODO: backport to previous commit
+	if tlsa == nil {
+		return nil, false, nil
 	}
 
 	safeCert, err := safetlsa.GetCertFromTLSA(domain, tlsa, s.tldCert, s.tldPriv)

--- a/server/server.go
+++ b/server/server.go
@@ -356,26 +356,7 @@ func (s *Server) indexHandler(writer http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (s *Server) lookupCert(req *http.Request) (certDer []byte, shortTerm bool, err error) {
-	commonName := req.FormValue("domain")
-
-	if commonName == "Namecoin Root CA" {
-		return s.rootCert, false, nil
-	}
-
-	if commonName == ".bit TLD CA" {
-		return s.tldCert, false, nil
-	}
-
-	domain := strings.TrimSuffix(commonName, " Domain AIA Parent CA")
-
-	if strings.Contains(domain, " ") {
-		// CommonNames that contain a space are usually CA's.  We
-		// already stripped the suffixes of Namecoin-formatted CA's, so
-		// if a space remains, just return no cert.
-		return nil, false, nil
-	}
-
+func (s *Server) lookupDNS(req *http.Request, domain string) (tlsa *dns.TLSA, err error) {
 	qparams := qlib.DefaultParams()
 	qparams.Port = s.cfg.DNSPort
 	qparams.Ad = true
@@ -396,25 +377,25 @@ func (s *Server) lookupCert(req *http.Request) (certDer []byte, shortTerm bool, 
 	if err != nil {
 		// A DNS error occurred.
 		log.Debuge(err, "qlib error")
-		return nil, false, fmt.Errorf("qlib error: %w", err)
+		return nil, fmt.Errorf("qlib error: %w", err)
 	}
 
 	if result.ResponseMsg == nil {
 		// A DNS error occurred (nil response).
-		return nil, false, fmt.Errorf("qlib error: nil response")
+		return nil, fmt.Errorf("qlib error: nil response")
 	}
 
 	dnsResponse := result.ResponseMsg
 	if dnsResponse.MsgHdr.Rcode != dns.RcodeSuccess && dnsResponse.MsgHdr.Rcode != dns.RcodeNameError {
 		// A DNS error occurred (return code wasn't Success or NXDOMAIN).
-		return nil, false, fmt.Errorf("qlib error: return code not Success or NXDOMAIN")
+		return nil, fmt.Errorf("qlib error: return code not Success or NXDOMAIN")
 	}
 
 	if dnsResponse.MsgHdr.Rcode == dns.RcodeNameError {
 		// Wildcard subdomain doesn't exist.
 		// That means the domain doesn't use Namecoin-form DANE.
 		// Return no cert.
-		return nil, false, nil
+		return nil, nil
 	}
 
 	if !dnsResponse.MsgHdr.AuthenticatedData && !dnsResponse.MsgHdr.Authoritative {
@@ -423,7 +404,7 @@ func (s *Server) lookupCert(req *http.Request) (certDer []byte, shortTerm bool, 
 		// DNSSEC sigs) or authoritative (e.g. server is ncdns and is
 		// the owner of the requested zone).  If neither is the case,
 		// then return no cert.
-		return nil, false, nil
+		return nil, nil
 	}
 
 	pubSHA256Hex := req.FormValue("pubsha256")
@@ -431,7 +412,7 @@ func (s *Server) lookupCert(req *http.Request) (certDer []byte, shortTerm bool, 
 	pubSHA256, err := hex.DecodeString(pubSHA256Hex)
 	if err != nil {
 		// Requested public key hash is malformed.
-		return nil, false, nil
+		return nil, nil
 	}
 
 	for _, rr := range dnsResponse.Answer {
@@ -462,17 +443,45 @@ func (s *Server) lookupCert(req *http.Request) (certDer []byte, shortTerm bool, 
 			continue
 		}
 
-		safeCert, err := safetlsa.GetCertFromTLSA(domain, tlsa, s.tldCert, s.tldPriv)
-		if err != nil {
-			continue
-		}
-
-		// Success.  Send the cert as a response.
-		return safeCert, true, nil
+		return tlsa, nil
 	}
 
 	// No DNS records matched. Return no cert.
-	return nil, false, nil
+	return nil, nil
+}
+
+func (s *Server) lookupCert(req *http.Request) (certDer []byte, shortTerm bool, err error) {
+	commonName := req.FormValue("domain")
+
+	if commonName == "Namecoin Root CA" {
+		return s.rootCert, false, nil
+	}
+
+	if commonName == ".bit TLD CA" {
+		return s.tldCert, false, nil
+	}
+
+	domain := strings.TrimSuffix(commonName, " Domain AIA Parent CA")
+
+	if strings.Contains(domain, " ") {
+		// CommonNames that contain a space are usually CA's.  We
+		// already stripped the suffixes of Namecoin-formatted CA's, so
+		// if a space remains, just return no cert.
+		return nil, false, nil
+	}
+
+	tlsa, err := lookupDNS(req, domain)
+	if err != nil {
+		return nil, false, err
+	}
+
+	safeCert, err := safetlsa.GetCertFromTLSA(domain, tlsa, s.tldCert, s.tldPriv)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Success.  Send the cert as a response.
+	return safeCert, true, nil
 }
 
 func (s *Server) writePemBundle(writer http.ResponseWriter, certs [][]byte) {


### PR DESCRIPTION
This is turned off at build-time by default. Enabling it probably opens up DoS vectors (hey let's calculate trillions of digits of Pi!), so it should only be used during testing, not in production.

TODO: Untested. Also need to clean up the Git history.