### PR TITLE
Support off-chain TLSA records (AIA only)

### DIFF
--- a/server/address.go
+++ b/server/address.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
+type AddressPassThrough string
+
+// EncodeAddress returns the string encoding of a pay-to-pubkey-hash
+// address.  Part of the Address interface.
+func (a AddressPassThrough) EncodeAddress() string {
+	return string(a)
+}
+
+// ScriptAddress returns the bytes to be included in a txout script to pay
+// to a pubkey hash.  Part of the Address interface.
+func (a AddressPassThrough) ScriptAddress() []byte {
+	return []byte{}
+}
+
+// IsForNet returns whether or not the pay-to-pubkey-hash address is associated
+// with the passed bitcoin network.
+func (a AddressPassThrough) IsForNet(net *chaincfg.Params) bool {
+	return false
+}
+
+// String returns a human-readable string for the pay-to-pubkey-hash address.
+// This is equivalent to calling EncodeAddress, but is provided so the type can
+// be used as a fmt.Stringer.
+func (a AddressPassThrough) String() string {
+	return a.EncodeAddress()
+}
+

--- a/server/server.go
+++ b/server/server.go
@@ -435,7 +435,8 @@ func (s *Server) lookupBlockchainMessage(req *http.Request, domain string) (tlsa
 
 	err = json.Unmarshal([]byte(sigsJSON), &sigs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to Unmarshal blockchain message sigs: %w", err)
+		log.Debugf("failed to Unmarshal blockchain message sigs for %s: %s", domain, err)
+		return nil, nil)
 	}
 
 	// TODO: stream isolation

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -24,10 +25,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/hlandau/xlog"
 	"github.com/miekg/dns"
 
 	"github.com/namecoin/crosssign"
+	"github.com/namecoin/ncbtcjson"
+	"github.com/namecoin/ncrpcclient"
 	"github.com/namecoin/qlib"
 	"github.com/namecoin/safetlsa"
 )
@@ -65,6 +70,8 @@ type Server struct {
 
 	tcpListener net.Listener
 	tlsListener net.Listener
+
+	namecoin *ncrpcclient.Client
 }
 
 //nolint:lll
@@ -77,6 +84,12 @@ type Config struct {
 	RootKey     string `default:"root_key.pem" usage:"Sign with this root CA private key."`
 	ListenChain string `default:"listen_chain.pem" usage:"Listen with this TLS certificate chain."`
 	ListenKey   string `default:"listen_key.pem" usage:"Listen with this TLS private key."`
+
+	NamecoinRPCUsername   string `default:"" usage:"Namecoin RPC username"`
+	NamecoinRPCPassword   string `default:"" usage:"Namecoin RPC password"`
+	NamecoinRPCAddress    string `default:"127.0.0.1:8336" usage:"Namecoin RPC server address"`
+	NamecoinRPCCookiePath string `default:"" usage:"Namecoin RPC cookie path (used if password is unspecified)"`
+	NamecoinRPCTimeout    int    `default:"1500" usage:"Timeout (in milliseconds) for Namecoin RPC requests"`
 
 	ConfigDir string // path to interpret filenames relative to
 }
@@ -128,6 +141,21 @@ func New(cfg *Config) (*Server, error) {
 	}
 
 	srv.tlsListener, err = net.ListenTCP("tcp", tlsAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Connect to local namecoin core RPC server using HTTP POST mode.
+	namecoinCfg := &rpcclient.ConnConfig{
+		Host:         cfg.NamecoinRPCAddress,
+		User:         cfg.NamecoinRPCUsername,
+		Pass:         cfg.NamecoinRPCPassword,
+		CookiePath:   cfg.NamecoinRPCCookiePath,
+		HTTPPostMode: true, // Namecoin core only supports HTTP POST mode
+		DisableTLS:   true, // Namecoin core does not provide TLS by default
+	}
+
+	srv.namecoin, err = ncrpcclient.New(namecoinCfg, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -358,6 +386,124 @@ func (s *Server) indexHandler(writer http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func (s *Server) lookupBlockchainMessage(req *http.Request, domain string) (tlsa *dns.TLSA, err error) {
+	pubBase64 := req.FormValue("pubb64")
+	sigsJSON := req.FormValue("sigs")
+
+	if pubBase64 == "" {
+		return nil, nil
+	}
+
+	if sigsJSON == "" {
+		return nil, nil
+	}
+
+	var blockchainName string
+
+	// Remove eTLD suffix
+	if strings.HasSuffix(domain, ".bit") {
+		blockchainName = strings.TrimSuffix(domain, ".bit")
+	} else if strings.HasSuffix(domain, ".bit.onion") {
+		blockchainName = strings.TrimSuffix(domain, ".bit.onion")
+	} else {
+		return nil, nil
+	}
+
+	// Remove subdomain labels
+	labels := strings.Split(blockchainName, ".")
+	blockchainName = labels[len(labels)-1]
+
+	// Prepend blockchain namespace
+	blockchainName = "d/" + blockchainName
+
+	// We use RawURLEncoding because it results in compact, readable URL's.
+	pubBytes, err := base64.RawURLEncoding.DecodeString(pubBase64)
+	if err != nil {
+		// Requested public key is malformed.
+		return nil, nil
+	}
+
+	pubHex := hex.EncodeToString(pubBytes)
+
+	sigs := []map[string]string{}
+
+	err = json.Unmarshal([]byte(sigsJSON), &sigs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Unmarshal blockchain message sigs: %w", err)
+	}
+
+	// TODO: stream isolation
+	nameData, err := s.namecoin.NameShow(blockchainName, &ncbtcjson.NameShowOptions{StreamID: ""})
+	if err != nil {
+		if jerr, ok := err.(*btcjson.RPCError); ok {
+			if jerr.Code == btcjson.ErrRPCWallet {
+				// ErrRPCWallet from name_show indicates that
+				// the name does not exist.
+				return nil, nil
+			}
+		}
+
+		// Some error besides NXDOMAIN happened; pass that error
+		// through unaltered.
+		return nil, err
+	}
+
+	nameAddress := nameData.Address
+
+	for _, sig := range sigs {
+		sigAddress, ok := sig["blockchainaddress"]
+		if !ok {
+			continue
+		}
+
+		if sigAddress != nameAddress {
+			continue
+		}
+
+		addressDecoded := AddressPassThrough(nameAddress)
+
+		messageHeader := "Namecoin X.509 Stapled Certification: "
+
+		messageData := map[string]string{
+			"domain": domain,
+			"x509pub": pubBase64,
+			"address": sigAddress,
+		}
+
+		messageDataBytes, err := json.Marshal(messageData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to Marshal blockchain message data: %w", err)
+		}
+
+		messageStr := messageHeader + string(messageDataBytes)
+
+		sigSig, ok := sig["blockchainsig"]
+		if !ok {
+			continue
+		}
+
+		verifyResult, err := s.namecoin.VerifyMessage(addressDecoded, sigSig, messageStr)
+		if err != nil {
+			continue
+		}
+		if !verifyResult {
+			continue
+		}
+
+		return &dns.TLSA{
+			Hdr: dns.RR_Header{Name: "", Rrtype: dns.TypeTLSA, Class: dns.ClassINET,
+				Ttl: 600},
+			Usage:        2,
+			Selector:     1,
+			MatchingType: 0,
+			Certificate:  strings.ToUpper(pubHex),
+		}, nil
+	}
+
+	// No sigs matched. Return no cert.
+	return nil, nil
+}
+
 func (s *Server) lookupDNS(req *http.Request, domain string) (tlsa *dns.TLSA, err error) {
 	qparams := qlib.DefaultParams()
 	qparams.Port = s.cfg.DNSPort
@@ -523,6 +669,13 @@ func (s *Server) lookupCert(req *http.Request) (certDer []byte, shortTerm bool, 
 	tlsa, err := s.lookupPi(req, domain)
 	if err != nil {
 		return nil, false, err
+	}
+
+	if tlsa == nil {
+		tlsa, err = s.lookupBlockchainMessage(req, domain)
+		if err != nil {
+			return nil, false, err
+		}
 	}
 
 	if tlsa == nil {


### PR DESCRIPTION
* Adds support for stapling a Namecoin message signature.
* This avoids the need for any on-chain TLSA records, saving some on-chain space.
* The signature can be revoked by transferring the name to a new Namecoin address.
* Address reuse is required if you want to update/renew your name *without* revoking the signature.
* Bitcoin Core only supports P2PKH addresses for this purpose.
* Electrum supports P2PKH and P2WPKH addresses.
* Smart contract addresses (e.g. multisig) are not currently supported by either Bitcoin Core or Electrum.
* This feature is currently AIA-only. PKCS#11 support will come later.